### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      # Available options: daily, weekly or monthly
+      interval: "daily"
+      # Random by default, have to be formated by hh:mm UTC
+      time: "06:06"
+      # Check the list of tz time zones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+      timezone: "Europe/Paris"
+    # Allow updates for Open Terms Archive engine
+    allow:
+      - dependency-name: "@opentermsarchive/engine"
+    # Add reviewers: that could be an individual reviewers with GitHub username or teams of reviewers with full team name (including the organization)
+    reviewers:
+      - "OpenTermsArchive/demo"
+    # Allow 3 open pull requests for dependencies (5 by default)
+    open-pull-requests-limit: 3


### PR DESCRIPTION
That changeset set up dependabot to update `@opentermsarchive/engine` automatically.

Before opening the pull requests on the other declarations repositories, I would like to have your opinion @Ndpnt @MattiSG on the value of `schedule` `reviewers` and `open-pull-requests-limit` parameters.

What I can say to explain my choices:
- `interval: "daily"` I guess if dependabot runs every day it's better and if it always runs at the same time it's easier to plan
- `time: "06:06"` I suggest that time because it sounds good and you have to choose one (ok and also because everyone will be able to remember the date of my birthday ^^) 
- `timezone: "Europe/Paris"` is the one on which our team organization is based, that can be adapted according to the needs of other declarations repositories
- `reviewers: - "OpenTermsArchive/demo"` I propose to always add the repo team in review so that she is mentioned
- `open-pull-requests-limit: 3` it seems to me less stressful and less invasive to have 3 open pull request maximum


