### PR TITLE
Lint on npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "lint": "ota lint",
     "lint:fix": "ota lint -- --fix",
-    "test": "ota validate",
-    "test:schema": "npm run test -- --schema-only",
-    "test:modified": "npm run test -- --modified",
+    "test": "ota lint && ota validate",
+    "test:schema": "ota validate --schema-only",
+    "test:modified": "ota validate --modified",
     "start": "ota track",
     "start:api": "ota serve",
     "start:schedule": "npm run start -- --schedule",


### PR DESCRIPTION
Decrease contributor surprise that tests pass locally and fail in CI.

Since [v0.26](https://github.com/OpenTermsArchive/engine/blob/main/CHANGELOG.md#0260---2023-02-20), `lint` and `validate` are independent, thus `npm test` does not run lint.
This is not a problem in CI, since both `lint` and `test:modified` are run, but I find it surprising for contributors that their tests pass locally and fail in CI.