### PR TITLE
Track our own terms

### DIFF
--- a/declarations/Brevo.json
+++ b/declarations/Brevo.json
@@ -1,0 +1,9 @@
+{
+  "name": "Brevo",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.brevo.com/legal/privacypolicy/",
+      "select": "main"
+    }
+  }
+}

--- a/declarations/Open Terms Archive.json
+++ b/declarations/Open Terms Archive.json
@@ -1,0 +1,13 @@
+{
+  "name": "Open Terms Archive",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://opentermsarchive.org/privacy-policy",
+      "select": ".TextContent_textContent__ToW2S"
+    },
+    "Imprint": {
+      "fetch": "https://opentermsarchive.org/legal-notice",
+      "select": ".TextContent_textContent__ToW2S"
+    }
+  }
+}


### PR DESCRIPTION
That changeset adds tracking of our own privacy policy and imprint terms, and Brevo privacy policy.