### PR TITLE
Run CI on PR changes (synchronize)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches-ignore:
       - 'main'
   pull_request:
-    types: [ opened, reopened ]
   workflow_call:
 
 jobs:


### PR DESCRIPTION
When a pull request gets updated through new commit pushes the CI does not run. It makes no sense to skip them on changes. CI shall specifically verify the *current state* of the PR - not only the first state and then ignore any changes.

> **`synchronize`**: A pull request's head branch was updated. For example, the head branch was updated from the base branch or new commits were pushed to the head branch.[1]

> By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened.[2]

[1]: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request
[2]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request